### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ value are identical to `hcubature`, above, except that now the integrand
 form. The integrand function `F` should now be a function of the form:
 
 ```c
-int f(unsigned ndim, unsigned npts, const double *x, void *fdata,
+int f(unsigned ndim, size_t npts, const double *x, void *fdata,
       unsigned fdim, double *fval);
 ```
 


### PR DESCRIPTION
integrand_v uses size_t (on 64bit systems aka long unsigned int) for npts and not unsigned